### PR TITLE
Huion H420 as HIDTablet configuration

### DIFF
--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -877,6 +877,8 @@ InitStrings 100 200
 
 
 #
+# Huion H420 (HID)
+#
 HIDTablet 0x256C 0x006E 0x000C 0x0001
 CheckString 6 "H420"
 Name "Huion H420"

--- a/TabletDriverService/config/tablet.cfg
+++ b/TabletDriverService/config/tablet.cfg
@@ -877,6 +877,20 @@ InitStrings 100 200
 
 
 #
+HIDTablet 0x256C 0x006E 0x000C 0x0001
+CheckString 6 "H420"
+Name "Huion H420"
+ReportLength 8
+DetectMask 0x80
+MaxX 8340
+MaxY 4680
+MaxPressure 2047
+Width 105.918
+Height 59.436
+InitStrings 100 200
+
+
+#
 # Huion H430P
 #
 USBTablet "{62F12D4C-3431-4EFD-8DD7-8E9AAB18D30C}"


### PR DESCRIPTION
Issue occured [here](https://github.com/hawku/TabletDriver/issues/423) where fix was to add a configuration identical to USBTablet H420 but as HIDTablet H420