### PR TITLE
Correct the dimensions of Wacom PTH-660

### DIFF
--- a/TabletDriverService/config/wacom.cfg
+++ b/TabletDriverService/config/wacom.cfg
@@ -688,8 +688,8 @@ DetectMask 0x40
 MaxX 44800
 MaxY 29600
 MaxPressure 8191
-Width 226.0
-Height 150.0
+Width 224.0
+Height 148.0
 TabletFormat WacomIntuosV3
 
 
@@ -704,8 +704,8 @@ DetectMask 0x40
 MaxX 44800
 MaxY 29600
 MaxPressure 8191
-Width 226.0
-Height 150.0
+Width 224.0
+Height 148.0
 TabletFormat WacomIntuosV3
 
 
@@ -719,8 +719,8 @@ DetectMask 0xE0
 MaxX 44800
 MaxY 29600
 MaxPressure 8191
-Width 226.0
-Height 150.0
+Width 224.0
+Height 148.0
 
 #
 # Wacom CTE-440 (Graphite4 4x5)


### PR DESCRIPTION
The area of PTH-660 is actually 224mm x 148mm.